### PR TITLE
Add Python 3.10+ compatibility

### DIFF
--- a/cachemodel/decorators.py
+++ b/cachemodel/decorators.py
@@ -3,7 +3,10 @@ from functools import wraps
 
 from cachemodel import CACHE_FOREVER_TIMEOUT
 from cachemodel.utils import generate_cache_key
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable  # For Python < 3.10
 
 def cached_method(auto_publish=False):
     """A decorator for CacheModel methods."""
@@ -21,7 +24,7 @@ def cached_method(auto_publish=False):
         wrapper._cached_method_target = target
         return wrapper
 
-    if isinstance(auto_publish, collections.Callable):
+    if isinstance(auto_publish, Callable):
         # we were used with no parens, fixup args 
         func = auto_publish
         auto_publish = False
@@ -47,7 +50,7 @@ def denormalized_field(field_name):
         wrapper._denormalized_field_name = field_name
         return wrapper
 
-    if isinstance(field_name, collections.Callable):
+    if isinstance(field_name, Callable):
         # we were used without an argument
         raise ArgumentErrror("You must pass a field name to @denormalized_field")
         

--- a/cachemodel/models.py
+++ b/cachemodel/models.py
@@ -20,7 +20,10 @@ from cachemodel import CACHE_FOREVER_TIMEOUT
 from cachemodel.managers import CacheModelManager, CachedTableManager
 from cachemodel.decorators import find_fields_decorated_with
 from cachemodel.utils import generate_cache_key
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable  # For Python < 3.10
 
 
 
@@ -85,7 +88,7 @@ class CacheModel(models.Model):
         if not getattr(method, '_cached_method', False):
             raise AttributeError("method '%s' is not a cached_method.");
         target = getattr(method, '_cached_method_target', None)
-        if isinstance(target, collections.Callable):
+        if isinstance(target, Callable):
             key = generate_cache_key([self.__class__.__name__, target.__name__, self.pk], *args, **kwargs)
             data = target(self, *args, **kwargs)
             cache.set(key, data, CACHE_FOREVER_TIMEOUT)

--- a/cachemodel/version.py
+++ b/cachemodel/version.py
@@ -1,1 +1,1 @@
-VERSION = (3, 0, 1)
+VERSION = (3, 1, 0)


### PR DESCRIPTION
## Description

In Python 3.10+ some imports are changed as in our example

`from collections import Callable`

was changed to

`from collections.abc import Callable`